### PR TITLE
feat(tools): add GitHub releases MCP toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
 # GitHub Releases MCP Server
 
-This MCP server provides access to GitHub repository releases information.
+A powerful Model Context Protocol (MCP) toolkit for GitHub releases management. This server provides comprehensive tools for accessing, comparing, and analyzing GitHub repository releases with rich formatting and detailed information.
+
+## Features
+
+- 🔍 **Detailed Release Information**: Get comprehensive details about specific releases
+- 📊 **Version Comparison**: Compare changes between any two versions
+- 📋 **Release Listing**: Get formatted lists of releases with filtering options
+- 🏷️ **Semantic Version Support**: Handles various version formats (v1.0.0, @1.0.0, 1.0.0)
+- 🎯 **Pre-release Filtering**: Option to include or exclude pre-releases
+- 📝 **Rich Formatting**: Emoji-enhanced output for better readability
+- 🔄 **Pagination Support**: Handles repositories with many releases
+- 🔒 **Authentication**: Optional GitHub token support for private repositories and extended rate limit
 
 ## Configuration
 
@@ -14,11 +25,11 @@ You can run this MCP server using npx:
 
 ```bash
 # Using environment variables
-GITHUB_PERSONAL_ACCESS_TOKEN=your_token npx @modelcontextprotocol/github-releases-mcp
+GITHUB_PERSONAL_ACCESS_TOKEN=your_token npx @slinerodev/github-releases-mcp
 
 # Or using a .env file
 echo "GITHUB_PERSONAL_ACCESS_TOKEN=your_token" > .env
-npx @modelcontextprotocol/github-releases-mcp
+npx @slinerodev/github-releases-mcp
 ```
 
 ## Client Configuration
@@ -70,32 +81,97 @@ Note:
 
 - For VS Code, replace `mcpServers` with `mcp.servers` in the configuration.
 - Replace `your_token_here` with your GitHub Personal Access Token if you want to access private repositories or need higher rate limits.
-- The local development version is typically used when working on the server code itself.
 
 ## Available Tools
 
-The server provides the following tool:
+The server provides three specialized tools for working with GitHub releases:
 
-- `github.releases`: Retrieves the list of releases from a GitHub repository.
+### 1. github_release_info
 
-### Parameters
-
-- `owner`: Repository owner (user or organization)
-- `repo`: Repository name
-
-### Example Response
+Get detailed information about a specific release version.
 
 ```typescript
+const result = await mcp.invoke("github_release_info", {
+  owner: "owner-name",
+  repo: "repo-name",
+  version: "1.0.0" // Supports v1.0.0, @1.0.0, 1.0.0
+});
+```
+
+Perfect for:
+
+- Understanding what changed in a specific version
+- Documentation purposes
+- Release note retrieval
+
+### 2. github_releases_compare
+
+Compare changes between two versions.
+
+```typescript
+const result = await mcp.invoke("github_releases_compare", {
+  owner: "owner-name",
+  repo: "repo-name",
+  fromVersion: "1.0.0",
+  toVersion: "2.0.0"
+});
+```
+
+Perfect for:
+
+- Generating changelogs
+- Understanding feature evolution
+- Migration guides
+- Breaking change analysis
+
+### 3. github_releases_list
+
+List all releases with filtering options.
+
+```typescript
+const result = await mcp.invoke("github_releases_list", {
+  owner: "owner-name",
+  repo: "repo-name",
+  limit: 10, // Optional: limit number of releases
+  includePreReleases: false // Optional: include pre-releases
+});
+```
+
+Perfect for:
+
+- Project release history overview
+- Finding latest versions
+- Release frequency monitoring
+- Pre-release tracking
+
+### Example Response Format
+
+All tools return responses in a consistent, emoji-enhanced format:
+
+```
 🔖 v1.0.0 (First stable release)
-🗓️ 2025-04-01T12:00:00Z
-📝 This is the first stable release of the project...
+🗓️ 2024-03-15T10:30:00Z
+📝 This is the release description...
 
 ---
 
-🔖 v0.9.0 (Beta)
-🗓️ 2025-03-15T10:30:00Z
-📝 Beta version with main features...
+🔖 v0.9.0 (Beta) (Pre-release)
+🗓️ 2024-03-01T08:15:00Z
+📝 Beta version with new features...
 ```
+
+## Error Handling
+
+The tools handle various error cases gracefully:
+
+- Invalid repository names
+- Non-existent versions
+- Invalid version formats
+- API rate limits
+- Network issues
+- Authentication errors
+
+Each error returns a clear message explaining what went wrong.
 
 ## Development
 
@@ -110,39 +186,6 @@ The server provides the following tool:
     ```bash
     pnpm start
     ```
-
-## Features
-
-- Fetches releases from any public GitHub repository
-- Displays release information including:
-  - Tag name
-  - Release name
-  - Publication date
-  - Release description (first 200 characters)
-- Handles errors gracefully
-- Uses GitHub's REST API
-- Optional authentication for private repositories and higher rate limits
-
-## Usage in MCP Environment
-
-This tool is designed to be used with the Model Context Protocol. To use it in your MCP-compatible environment:
-
-```typescript
-const result = await mcp.invoke("github.releases", {
-  owner: "owner-name",
-  repo: "repo-name"
-});
-```
-
-### Error Handling
-
-The tool handles various error cases:
-
-- Invalid repository
-- No releases found
-- API rate limits
-- Network issues
-- Authentication errors
 
 ## Contributing
 

--- a/dist/logger.d.ts
+++ b/dist/logger.d.ts
@@ -1,0 +1,15 @@
+export declare enum LogLevel {
+    DEBUG = 0,
+    INFO = 1,
+    WARN = 2,
+    ERROR = 3
+}
+export declare class Logger {
+    private static level;
+    static setLevel(level: LogLevel): void;
+    private static formatMessage;
+    static debug(message: string, context?: any): void;
+    static info(message: string, context?: any): void;
+    static warn(message: string, context?: any): void;
+    static error(message: string, error?: Error | any): void;
+}

--- a/dist/logger.js
+++ b/dist/logger.js
@@ -1,0 +1,43 @@
+export var LogLevel;
+(function (LogLevel) {
+    LogLevel[LogLevel["DEBUG"] = 0] = "DEBUG";
+    LogLevel[LogLevel["INFO"] = 1] = "INFO";
+    LogLevel[LogLevel["WARN"] = 2] = "WARN";
+    LogLevel[LogLevel["ERROR"] = 3] = "ERROR";
+})(LogLevel || (LogLevel = {}));
+export class Logger {
+    static level = LogLevel.INFO;
+    static setLevel(level) {
+        this.level = level;
+    }
+    static formatMessage(level, message, context) {
+        const timestamp = new Date().toISOString();
+        const contextStr = context ? `\n${JSON.stringify(context, null, 2)}` : '';
+        return `[${timestamp}] ${level}: ${message}${contextStr}`;
+    }
+    static debug(message, context) {
+        if (this.level <= LogLevel.DEBUG) {
+            console.debug(this.formatMessage('DEBUG', message, context));
+        }
+    }
+    static info(message, context) {
+        if (this.level <= LogLevel.INFO) {
+            console.info(this.formatMessage('INFO', message, context));
+        }
+    }
+    static warn(message, context) {
+        if (this.level <= LogLevel.WARN) {
+            console.warn(this.formatMessage('WARN', message, context));
+        }
+    }
+    static error(message, error) {
+        if (this.level <= LogLevel.ERROR) {
+            console.error(this.formatMessage('ERROR', message, {
+                error: error instanceof Error ? {
+                    message: error.message,
+                    stack: error.stack
+                } : error
+            }));
+        }
+    }
+}

--- a/dist/main.js
+++ b/dist/main.js
@@ -2,50 +2,135 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-// Función para obtener la configuración de GitHub
-function getGitHubConfig() {
-    return {
-        token: process.env.GITHUB_PERSONAL_ACCESS_TOKEN,
-        headers: {
-            "Accept": "application/vnd.github+json",
-            "User-Agent": "mcp-github-releases-server",
-            ...(process.env.GITHUB_PERSONAL_ACCESS_TOKEN && {
-                "Authorization": `Bearer ${process.env.GITHUB_PERSONAL_ACCESS_TOKEN}`
-            })
-        }
-    };
-}
-// Input schema definition using Zod
-const schema = {
-    owner: z.string().describe("GitHub repository owner"),
-    repo: z.string().describe("GitHub repository name"),
-};
+import { getGitHubConfig, formatRelease, fetchAllReleases, fetchReleaseByVersion, fetchReleasesBetweenVersions } from "./utils.js";
 // Create MCP server
 const server = new McpServer({
     name: "GitHub Releases MCP Server",
     version: "1.0.0",
 });
-// Register 'github_releases' tool
-server.tool("github_releases", "Get the list of releases from a GitHub repository.", schema, async ({ owner, repo }) => {
-    const url = `https://api.github.com/repos/${owner}/${repo}/releases`;
+// Helper function for logging
+function log(level, message) {
+    const timestamp = new Date().toISOString();
+    process.stderr.write(`[${timestamp}] ${level.toUpperCase()}: ${message}\n`);
+}
+// Schema definitions
+const baseSchema = {
+    owner: z.string().describe("GitHub repository owner"),
+    repo: z.string().describe("GitHub repository name"),
+};
+const releaseInfoSchema = {
+    ...baseSchema,
+    version: z.string().describe("The specific version to get information about (supports formats: v1.0.0, @1.0.0, 1.0.0)")
+};
+const releasesCompareSchema = {
+    ...baseSchema,
+    fromVersion: z.string().describe("The base version to compare from (supports formats: v1.0.0, @1.0.0, 1.0.0)"),
+    toVersion: z.string().describe("The target version to compare to (supports formats: v1.0.0, @1.0.0, 1.0.0)")
+};
+const releasesListSchema = {
+    ...baseSchema,
+    limit: z.number().optional().describe("Maximum number of releases to return (default: all)"),
+    includePreReleases: z.boolean().optional().describe("Whether to include pre-releases in the results (default: false)")
+};
+// Register 'github_release_info' tool
+server.tool("github_release_info", "Get detailed information about a specific GitHub release version. Supports semantic versioning formats (v1.0.0, @1.0.0, 1.0.0) and returns comprehensive release details including tag name, release title, publication date, and full release notes. Perfect for understanding what changed in a specific version or for documentation purposes.", releaseInfoSchema, async ({ owner, repo, version }, context) => {
     const config = getGitHubConfig();
     try {
-        const response = await fetch(url, {
-            headers: config.headers
-        });
-        if (!response.ok) {
+        log('info', `Fetching release info for ${owner}/${repo}@${version}`);
+        const release = await fetchReleaseByVersion(owner, repo, version, config);
+        if (!release) {
+            log('warn', `No release found for version ${version}`);
             return {
                 content: [
                     {
                         type: "text",
-                        text: `Error fetching releases: ${response.status} ${response.statusText}`,
+                        text: `No release found for version ${version} in repository ${owner}/${repo}.`,
                     },
                 ],
-                isError: true,
             };
         }
-        const data = await response.json();
-        if (!Array.isArray(data) || data.length === 0) {
+        log('info', `Successfully retrieved release info for ${release.tag_name}`);
+        return {
+            content: [
+                {
+                    type: "text",
+                    text: formatRelease(release, true), // true for full description
+                },
+            ],
+        };
+    }
+    catch (error) {
+        log('error', `Error fetching release info: ${error.message}`);
+        return {
+            content: [
+                {
+                    type: "text",
+                    text: `Error fetching release info: ${error.message}`,
+                },
+            ],
+            isError: true,
+        };
+    }
+});
+// Register 'github_releases_compare' tool
+server.tool("github_releases_compare", "Compare changes between two GitHub release versions. Ideal for understanding what changed between versions, generating changelogs, or migration guides. Returns a chronological list of all releases between the two versions with their full release notes, making it perfect for analyzing the evolution of features, bug fixes, and breaking changes. Supports semantic versioning formats (v1.0.0, @1.0.0, 1.0.0).", releasesCompareSchema, async ({ owner, repo, fromVersion, toVersion }, context) => {
+    const config = getGitHubConfig();
+    try {
+        log('info', `Comparing releases between ${fromVersion} and ${toVersion} for ${owner}/${repo}`);
+        const releases = await fetchReleasesBetweenVersions(owner, repo, fromVersion, toVersion, config);
+        if (releases.length === 0) {
+            log('warn', `No releases found between versions ${fromVersion} and ${toVersion}`);
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: `No releases found between versions ${fromVersion} and ${toVersion} in repository ${owner}/${repo}.`,
+                    },
+                ],
+            };
+        }
+        log('info', `Found ${releases.length} releases between ${fromVersion} and ${toVersion}`);
+        const formattedReleases = releases
+            .map(release => formatRelease(release, true))
+            .join("\n\n---\n\n");
+        return {
+            content: [
+                {
+                    type: "text",
+                    text: `Changes between ${fromVersion} and ${toVersion}:\n\n${formattedReleases}`,
+                },
+            ],
+        };
+    }
+    catch (error) {
+        log('error', `Error comparing releases: ${error.message}`);
+        return {
+            content: [
+                {
+                    type: "text",
+                    text: `Error comparing releases: ${error.message}`,
+                },
+            ],
+            isError: true,
+        };
+    }
+});
+// Register 'github_releases_list' tool
+server.tool("github_releases_list", "List all GitHub releases for a repository with rich formatting and comprehensive details. Returns releases in chronological order with emojis for better readability (🔖 for versions, 🗓️ for dates, 📝 for descriptions). Perfect for getting an overview of a project's release history, finding the latest version, or monitoring release frequency. Supports pagination and filtering of pre-releases.", releasesListSchema, async ({ owner, repo, limit, includePreReleases = false }, context) => {
+    const config = getGitHubConfig();
+    try {
+        log('info', `Fetching releases for ${owner}/${repo} (limit: ${limit || 'none'}, includePreReleases: ${includePreReleases})`);
+        let releases = await fetchAllReleases(owner, repo, config);
+        // Filter pre-releases if needed
+        if (!includePreReleases) {
+            releases = releases.filter(release => !release.prerelease);
+        }
+        // Apply limit if specified
+        if (limit && limit > 0) {
+            releases = releases.slice(0, limit);
+        }
+        if (releases.length === 0) {
+            log('warn', `No releases found for ${owner}/${repo}`);
             return {
                 content: [
                     {
@@ -55,16 +140,10 @@ server.tool("github_releases", "Get the list of releases from a GitHub repositor
                 ],
             };
         }
-        const releases = data.map((release) => ({
-            id: release.id,
-            tag_name: release.tag_name,
-            name: release.name,
-            published_at: release.published_at,
-            body: release.body,
-        }));
+        log('info', `Found ${releases.length} releases for ${owner}/${repo}`);
         const formattedReleases = releases
-            .map((r) => `🔖 ${r.tag_name} (${r.name})\n🗓️ ${r.published_at}\n📝 ${r.body?.slice(0, 200) ?? "No description"}\n`)
-            .join("\n---\n");
+            .map(release => formatRelease(release))
+            .join("\n\n---\n\n");
         return {
             content: [
                 {
@@ -75,11 +154,12 @@ server.tool("github_releases", "Get the list of releases from a GitHub repositor
         };
     }
     catch (error) {
+        log('error', `Error fetching releases: ${error.message}`);
         return {
             content: [
                 {
                     type: "text",
-                    text: `Exception while fetching releases: ${error.message}`,
+                    text: `Error fetching releases: ${error.message}`,
                 },
             ],
             isError: true,
@@ -88,4 +168,6 @@ server.tool("github_releases", "Get the list of releases from a GitHub repositor
 });
 // Connect server using stdio transport
 const transport = new StdioServerTransport();
+// Log server startup
+log('info', 'GitHub Releases MCP Server starting up');
 await server.connect(transport);

--- a/dist/utils.d.ts
+++ b/dist/utils.d.ts
@@ -1,0 +1,22 @@
+export interface GitHubConfig {
+    token?: string;
+    headers: {
+        Accept: string;
+        "User-Agent": string;
+        Authorization?: string;
+    };
+}
+export interface GitHubRelease {
+    id: number;
+    tag_name: string;
+    name: string;
+    published_at: string;
+    body?: string;
+    prerelease: boolean;
+}
+export declare function getGitHubConfig(): GitHubConfig;
+export declare function extractVersion(tagName: string): string | null;
+export declare function formatRelease(release: GitHubRelease, fullDescription?: boolean): string;
+export declare function fetchAllReleases(owner: string, repo: string, config: GitHubConfig): Promise<GitHubRelease[]>;
+export declare function fetchReleaseByVersion(owner: string, repo: string, version: string, config: GitHubConfig): Promise<GitHubRelease | null>;
+export declare function fetchReleasesBetweenVersions(owner: string, repo: string, fromVersion: string, toVersion: string, config: GitHubConfig): Promise<GitHubRelease[]>;

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -1,0 +1,97 @@
+import * as semver from "semver";
+import { Logger } from "./logger";
+// Get GitHub configuration with optional token
+export function getGitHubConfig() {
+    const token = process.env.GITHUB_PERSONAL_ACCESS_TOKEN;
+    Logger.info(`GitHub token: ${token}`);
+    return {
+        token,
+        headers: {
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "mcp-github-releases-server",
+            ...(token && {
+                "Authorization": `Bearer ${token}`
+            })
+        }
+    };
+}
+// Extract clean version from tag name
+export function extractVersion(tagName) {
+    const versionMatch = tagName.match(/@(\d+\.\d+\.\d+)$/) || tagName.match(/^v?(\d+\.\d+\.\d+)/);
+    return versionMatch ? semver.clean(versionMatch[1]) : semver.clean(tagName);
+}
+// Format a release for display
+export function formatRelease(release, fullDescription = false) {
+    const description = fullDescription ? release.body : release.body?.slice(0, 200);
+    return `🔖 ${release.tag_name}${release.prerelease ? ' (Pre-release)' : ''} (${release.name || 'Unnamed release'})
+🗓️ ${new Date(release.published_at).toISOString()}
+📝 ${description ?? 'No description provided'}`;
+}
+// Fetch all releases with pagination
+export async function fetchAllReleases(owner, repo, config) {
+    let page = 1;
+    let allReleases = [];
+    const perPage = 100; // Maximum allowed by GitHub API
+    while (true) {
+        const url = `https://api.github.com/repos/${owner}/${repo}/releases?page=${page}&per_page=${perPage}`;
+        try {
+            const response = await fetch(url, { headers: config.headers }).catch((error) => {
+                Logger.error(`Error fetching releases: ${error instanceof Error ? error.message : String(error)}`);
+                throw new Error(`Error fetching releases: ${error instanceof Error ? error.message : String(error)}`);
+            });
+            if (!response.ok) {
+                throw new Error(`Error fetching releases: ${response.status} ${response.statusText}`);
+            }
+            const releases = await response.json();
+            if (!Array.isArray(releases) || releases.length === 0) {
+                break;
+            }
+            allReleases = allReleases.concat(releases);
+            if (releases.length < perPage) {
+                break;
+            }
+            page++;
+        }
+        catch (error) {
+            Logger.error(`Failed to fetch releases from GitHub: ${error instanceof Error ? error.message : String(error)}`);
+            throw new Error(`Failed to fetch releases from GitHub: ${error instanceof Error ? error.message : String(error)}`);
+        }
+    }
+    return allReleases;
+}
+// Get a specific release by version
+export async function fetchReleaseByVersion(owner, repo, version, config) {
+    const releases = await fetchAllReleases(owner, repo, config);
+    const cleanTargetVersion = extractVersion(version);
+    if (!cleanTargetVersion) {
+        throw new Error(`Invalid version format: ${version}`);
+    }
+    return releases.find(release => {
+        const releaseVersion = extractVersion(release.tag_name);
+        return releaseVersion && semver.eq(releaseVersion, cleanTargetVersion);
+    }) || null;
+}
+// Get releases between two versions
+export async function fetchReleasesBetweenVersions(owner, repo, fromVersion, toVersion, config) {
+    const releases = await fetchAllReleases(owner, repo, config);
+    Logger.info(`Fetched ${releases.length} releases for ${owner}/${repo}`);
+    const cleanFromVersion = extractVersion(fromVersion);
+    const cleanToVersion = extractVersion(toVersion);
+    Logger.info(`Clean from version: ${cleanFromVersion}`);
+    Logger.info(`Clean to version: ${cleanToVersion}`);
+    if (!cleanFromVersion || !cleanToVersion) {
+        throw new Error(`Invalid version format: ${!cleanFromVersion ? fromVersion : toVersion}`);
+    }
+    return releases
+        .filter(release => {
+        const version = extractVersion(release.tag_name);
+        if (!version)
+            return false;
+        return semver.gte(version, cleanFromVersion) && semver.lte(version, cleanToVersion);
+    })
+        .sort((a, b) => {
+        const versionA = extractVersion(a.tag_name) || '';
+        const versionB = extractVersion(b.tag_name) || '';
+        return semver.compare(versionA, versionB);
+    });
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@slinerodev/github-releases-mcp",
-  "version": "0.0.2",
-  "description": "A Model Context Protocol (MCP) tool that fetches and displays GitHub repository releases in a formatted way",
+  "version": "0.1.0",
+  "description": "A Model Context Protocol (MCP) toolkit for GitHub releases management. Features include detailed release information, version comparison, and release listing with rich formatting. Perfect for changelog generation, version tracking, and release documentation.",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",
   "type": "module",
@@ -23,13 +23,19 @@
     "mcp",
     "github",
     "releases",
-    "modelcontextprotocol"
+    "modelcontextprotocol",
+    "changelog",
+    "version-comparison",
+    "release-management",
+    "semantic-versioning"
   ],
   "author": "Sergio Linero",
   "license": "ISC",
   "packageManager": "pnpm@10.6.3+sha512.bb45e34d50a9a76e858a95837301bfb6bd6d35aea2c5d52094fa497a467c43f5c440103ce2511e9e0a2f89c3d6071baac3358fc68ac6fb75e2ceb3d2736065e6",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.10.2",
+    "@types/semver": "^7.7.0",
+    "semver": "^7.7.1",
     "zod": "^3.24.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.10.2
         version: 1.10.2
+      '@types/semver':
+        specifier: ^7.7.0
+        version: 7.7.0
+      semver:
+        specifier: ^7.7.1
+        version: 7.7.1
       zod:
         specifier: ^3.24.3
         version: 3.24.3
@@ -21,6 +27,9 @@ importers:
       tsx:
         specifier: ^4.7.1
         version: 4.19.3
+      typescript:
+        specifier: ^5.4.2
+        version: 5.8.3
 
 packages:
 
@@ -180,6 +189,9 @@ packages:
 
   '@types/node@22.15.2':
     resolution: {integrity: sha512-uKXqKN9beGoMdBfcaTY1ecwz6ctxuJAcUlwE55938g0ZJ8lRxwAZqRz2AJ4pzpt5dHdTPMB863UZ0ESiFUcP7A==}
+
+  '@types/semver@7.7.0':
+    resolution: {integrity: sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -442,6 +454,11 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  semver@7.7.1:
+    resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@1.2.0:
     resolution: {integrity: sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==}
     engines: {node: '>= 18'}
@@ -493,6 +510,11 @@ packages:
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
+
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -616,6 +638,8 @@ snapshots:
   '@types/node@22.15.2':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/semver@7.7.0': {}
 
   accepts@2.0.0:
     dependencies:
@@ -907,6 +931,8 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  semver@7.7.1: {}
+
   send@1.2.0:
     dependencies:
       debug: 4.4.0
@@ -984,6 +1010,8 @@ snapshots:
       content-type: 1.0.5
       media-typer: 1.1.0
       mime-types: 3.0.1
+
+  typescript@5.8.3: {}
 
   undici-types@6.21.0: {}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,26 +3,14 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-
-// Función para obtener la configuración de GitHub
-function getGitHubConfig() {
-  return {
-    token: process.env.GITHUB_PERSONAL_ACCESS_TOKEN,
-    headers: {
-      "Accept": "application/vnd.github+json",
-      "User-Agent": "mcp-github-releases-server",
-      ...(process.env.GITHUB_PERSONAL_ACCESS_TOKEN && {
-        "Authorization": `Bearer ${process.env.GITHUB_PERSONAL_ACCESS_TOKEN}`
-      })
-    }
-  };
-}
-
-// Input schema definition using Zod
-const schema = {
-  owner: z.string().describe("GitHub repository owner"),
-  repo: z.string().describe("GitHub repository name"),
-};
+import {
+  getGitHubConfig,
+  formatRelease,
+  fetchAllReleases,
+  fetchReleaseByVersion,
+  fetchReleasesBetweenVersions,
+  GitHubRelease
+} from "./utils.js";
 
 // Create MCP server
 const server = new McpServer({
@@ -30,35 +18,143 @@ const server = new McpServer({
   version: "1.0.0",
 });
 
-// Register 'github_releases' tool
+// Schema definitions
+const baseSchema = {
+  owner: z.string().describe("GitHub repository owner"),
+  repo: z.string().describe("GitHub repository name"),
+};
+
+const releaseInfoSchema = {
+  ...baseSchema,
+  version: z.string().describe("The specific version to get information about (supports formats: v1.0.0, @1.0.0, 1.0.0)")
+};
+
+const releasesCompareSchema = {
+  ...baseSchema,
+  fromVersion: z.string().describe("The base version to compare from (supports formats: v1.0.0, @1.0.0, 1.0.0)"),
+  toVersion: z.string().describe("The target version to compare to (supports formats: v1.0.0, @1.0.0, 1.0.0)")
+};
+
+const releasesListSchema = {
+  ...baseSchema,
+  limit: z.number().optional().describe("Maximum number of releases to return (default: all)"),
+  includePreReleases: z.boolean().optional().describe("Whether to include pre-releases in the results (default: false)")
+};
+
+// Register 'github_release_info' tool
 server.tool(
-  "github_releases",
-  "Get the list of releases from a GitHub repository.",
-  schema,
-  async ({ owner, repo }) => {
-    const url = `https://api.github.com/repos/${owner}/${repo}/releases`;
+  "github_release_info",
+  "Get detailed information about a specific GitHub release version. Supports semantic versioning formats (v1.0.0, @1.0.0, 1.0.0) and returns comprehensive release details including tag name, release title, publication date, and full release notes. Perfect for understanding what changed in a specific version or for documentation purposes.",
+  releaseInfoSchema,
+  async ({ owner, repo, version }, context) => {
     const config = getGitHubConfig();
 
     try {
-      const response = await fetch(url, {
-        headers: config.headers
-      });
+      const release = await fetchReleaseByVersion(owner, repo, version, config);
 
-      if (!response.ok) {
+      if (!release) {
         return {
           content: [
             {
               type: "text",
-              text: `Error fetching releases: ${response.status} ${response.statusText}`,
+              text: `No release found for version ${version} in repository ${owner}/${repo}.`,
             },
           ],
-          isError: true,
         };
       }
 
-      const data = await response.json();
+      return {
+        content: [
+          {
+            type: "text",
+            text: formatRelease(release, true), // true for full description
+          },
+        ],
+      };
+    } catch (error: any) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error fetching release info: ${error.message}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  }
+);
 
-      if (!Array.isArray(data) || data.length === 0) {
+// Register 'github_releases_compare' tool
+server.tool(
+  "github_releases_compare",
+  "Compare changes between two GitHub release versions. Ideal for understanding what changed between versions, generating changelogs, or migration guides. Returns a chronological list of all releases between the two versions with their full release notes, making it perfect for analyzing the evolution of features, bug fixes, and breaking changes. Supports semantic versioning formats (v1.0.0, @1.0.0, 1.0.0).",
+  releasesCompareSchema,
+  async ({ owner, repo, fromVersion, toVersion }, context) => {
+    const config = getGitHubConfig();
+
+    try {
+      const releases = await fetchReleasesBetweenVersions(owner, repo, fromVersion, toVersion, config);
+
+      if (releases.length === 0) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `No releases found between versions ${fromVersion} and ${toVersion} in repository ${owner}/${repo}.`,
+            },
+          ],
+        };
+      }
+
+      const formattedReleases = releases
+        .map(release => formatRelease(release, true))
+        .join("\n\n---\n\n");
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Changes between ${fromVersion} and ${toVersion}:\n\n${formattedReleases}`,
+          },
+        ],
+      };
+    } catch (error: any) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error comparing releases: ${error.message}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  }
+);
+
+// Register 'github_releases_list' tool
+server.tool(
+  "github_releases_list",
+  "List all GitHub releases for a repository with rich formatting and comprehensive details. Returns releases in chronological order with emojis for better readability (🔖 for versions, 🗓️ for dates, 📝 for descriptions). Perfect for getting an overview of a project's release history, finding the latest version, or monitoring release frequency. Supports pagination and filtering of pre-releases.",
+  releasesListSchema,
+  async ({ owner, repo, limit, includePreReleases = false }, context) => {
+    const config = getGitHubConfig();
+
+    try {
+      let releases = await fetchAllReleases(owner, repo, config);
+
+      // Filter pre-releases if needed
+      if (!includePreReleases) {
+        releases = releases.filter(release => !release.prerelease);
+      }
+
+      // Apply limit if specified
+      if (limit && limit > 0) {
+        releases = releases.slice(0, limit);
+      }
+
+      if (releases.length === 0) {
         return {
           content: [
             {
@@ -69,20 +165,9 @@ server.tool(
         };
       }
 
-      const releases = data.map((release: any) => ({
-        id: release.id,
-        tag_name: release.tag_name,
-        name: release.name,
-        published_at: release.published_at,
-        body: release.body,
-      }));
-
       const formattedReleases = releases
-        .map(
-          (r) =>
-            `🔖 ${r.tag_name} (${r.name})\n🗓️ ${r.published_at}\n📝 ${r.body?.slice(0, 200) ?? "No description"}\n`
-        )
-        .join("\n---\n");
+        .map(release => formatRelease(release))
+        .join("\n\n---\n\n");
 
       return {
         content: [
@@ -97,7 +182,7 @@ server.tool(
         content: [
           {
             type: "text",
-            text: `Exception while fetching releases: ${error.message}`,
+            text: `Error fetching releases: ${error.message}`,
           },
         ],
         isError: true,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,138 @@
+import * as semver from "semver";
+
+export interface GitHubConfig {
+  token?: string;
+  headers: {
+    Accept: string;
+    "User-Agent": string;
+    Authorization?: string;
+  };
+}
+
+export interface GitHubRelease {
+  id: number;
+  tag_name: string;
+  name: string;
+  published_at: string;
+  body?: string;
+  prerelease: boolean;
+}
+
+// Get GitHub configuration with optional token
+export function getGitHubConfig(): GitHubConfig {
+  const token = process.env.GITHUB_PERSONAL_ACCESS_TOKEN;
+  return {
+    token,
+    headers: {
+      "Accept": "application/vnd.github+json",
+      "User-Agent": "mcp-github-releases-server",
+      ...(token && {
+        "Authorization": `Bearer ${token}`
+      })
+    }
+  };
+}
+
+// Extract clean version from tag name
+export function extractVersion(tagName: string): string | null {
+  const versionMatch = tagName.match(/@(\d+\.\d+\.\d+)$/) || tagName.match(/^v?(\d+\.\d+\.\d+)/);
+  return versionMatch ? semver.clean(versionMatch[1]) : semver.clean(tagName);
+}
+
+// Format a release for display
+export function formatRelease(release: GitHubRelease, fullDescription: boolean = false): string {
+  const description = fullDescription ? release.body : release.body?.slice(0, 200);
+  return `🔖 ${release.tag_name}${release.prerelease ? ' (Pre-release)' : ''} (${release.name || 'Unnamed release'})
+🗓️ ${new Date(release.published_at).toISOString()}
+📝 ${description ?? 'No description provided'}`;
+}
+
+// Fetch all releases with pagination
+export async function fetchAllReleases(
+  owner: string, 
+  repo: string, 
+  config: GitHubConfig
+): Promise<GitHubRelease[]> {
+  let page = 1;
+  let allReleases: GitHubRelease[] = [];
+  const perPage = 100; // Maximum allowed by GitHub API
+
+  while (true) {
+    const url = `https://api.github.com/repos/${owner}/${repo}/releases?page=${page}&per_page=${perPage}`;
+    
+    try {
+      const response = await fetch(url, { headers: config.headers })
+
+      if (!response.ok) {
+        throw new Error(`Error fetching releases: ${response.status} ${response.statusText}`);
+      }
+
+      const releases = await response.json();
+      
+      if (!Array.isArray(releases) || releases.length === 0) {
+        break;
+      }
+
+      allReleases = allReleases.concat(releases);
+
+      if (releases.length < perPage) {
+        break;
+      }
+
+      page++;
+    } catch (error) {
+      throw new Error(`Failed to fetch releases from GitHub: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  return allReleases;
+}
+
+// Get a specific release by version
+export async function fetchReleaseByVersion(
+  owner: string,
+  repo: string,
+  version: string,
+  config: GitHubConfig
+): Promise<GitHubRelease | null> {
+  const releases = await fetchAllReleases(owner, repo, config);
+  const cleanTargetVersion = extractVersion(version);
+  
+  if (!cleanTargetVersion) {
+    throw new Error(`Invalid version format: ${version}`);
+  }
+
+  return releases.find(release => {
+    const releaseVersion = extractVersion(release.tag_name);
+    return releaseVersion && semver.eq(releaseVersion, cleanTargetVersion);
+  }) || null;
+}
+
+// Get releases between two versions
+export async function fetchReleasesBetweenVersions(
+  owner: string,
+  repo: string,
+  fromVersion: string,
+  toVersion: string,
+  config: GitHubConfig
+): Promise<GitHubRelease[]> {
+  const releases = await fetchAllReleases(owner, repo, config);
+  const cleanFromVersion = extractVersion(fromVersion);
+  const cleanToVersion = extractVersion(toVersion);
+
+  if (!cleanFromVersion || !cleanToVersion) {
+    throw new Error(`Invalid version format: ${!cleanFromVersion ? fromVersion : toVersion}`);
+  }
+
+  return releases
+    .filter(release => {
+      const version = extractVersion(release.tag_name);
+      if (!version) return false;
+      return semver.gte(version, cleanFromVersion) && semver.lte(version, cleanToVersion);
+    })
+    .sort((a, b) => {
+      const versionA = extractVersion(a.tag_name) || '';
+      const versionB = extractVersion(b.tag_name) || '';
+      return semver.compare(versionA, versionB);
+    });
+} 


### PR DESCRIPTION
Implements a new Model Context Protocol toolkit for managing GitHub releases. Includes semantic versioning support, release information formatting, and MCP SDK integration. Provides both programmatic and CLI interfaces for release management operations.